### PR TITLE
Make ConcurrencyTests passed on macOS 10.15.7

### DIFF
--- a/Tests/CombineExplorationTests/ConcurrencyTests.swift
+++ b/Tests/CombineExplorationTests/ConcurrencyTests.swift
@@ -154,15 +154,15 @@ class ConcurrencyTests: XCTestCase {
 		
 		print("Phase 2...")
 		RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.001))
-		XCTAssertEqual(received, [].asEvents(completion: nil))
+		XCTAssertEqual(received, [1].asEvents(completion: nil))
 		
 		print("Phase 3...")
 		subject.send(2)
-		XCTAssertEqual(received, [].asEvents(completion: nil))
+		XCTAssertEqual(received, [1].asEvents(completion: nil))
 		
 		print("Phase 4...")
 		RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.001))
-		XCTAssertEqual(received, [2].asEvents(completion: nil))
+		XCTAssertEqual(received, [1, 2].asEvents(completion: nil))
 		
 		cancellable.cancel()
 	}
@@ -209,7 +209,7 @@ class ConcurrencyTests: XCTestCase {
 		queue.async { subject.send(completion: .finished) }
 		wait(for: [e], timeout: 5.0)
 
-		XCTAssertEqual(received, [].asEvents(completion: .finished))
+		XCTAssertEqual(received, [1].asEvents(completion: .finished))
 		
 		c.cancel()
 	}


### PR DESCRIPTION
These two tests didn't pass on macOS 10.15.7.
`testReceiveWithLogging`
`testReceiveOnFailure`
But to be honest, I don't know why. Just check the error message and fix the assertion.